### PR TITLE
Enable CREATE_WAITABLE_TIMER_HIGH_RESOLUTION flag in Win32TimerImplementation.cs

### DIFF
--- a/src/Implementations/Win32TimerImplementation.cs
+++ b/src/Implementations/Win32TimerImplementation.cs
@@ -7,18 +7,24 @@ namespace Haukcode.HighResolutionTimer.Implementations
 {
     internal sealed class Win32TimerImplementation : ITimerImplementation
     {
+        // High-resolution waitable timers (Windows 10 1803+) are not quantized to the
+        // ~15.6ms system clock tick, so short periods like 1ms are honored accurately
+        // without raising the global timer resolution via timeBeginPeriod.
+        private const uint CreateWaitableTimerHighResolution = 0x00000002;
+        private const uint TimerAllAccess = 0x1F0003;
+
         private readonly IntPtr handle;
         private TimeSpan period;
-        
+
         public Win32TimerImplementation()
         {
-            var timer = CreateWaitableTimer(IntPtr.Zero, false, IntPtr.Zero);
+            var timer = CreateWaitableTimerEx(IntPtr.Zero, IntPtr.Zero, CreateWaitableTimerHighResolution, TimerAllAccess);
 
             if (timer == IntPtr.Zero)
             {
                 ThrowWin32Exception();
             }
-            
+
             this.handle = timer;
         }
         
@@ -91,10 +97,11 @@ namespace Haukcode.HighResolutionTimer.Implementations
         }
         
         [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern IntPtr CreateWaitableTimer(
+        private static extern IntPtr CreateWaitableTimerEx(
             IntPtr lpTimerAttributes,
-            bool bManualReset,
-            IntPtr lpTimerName);
+            IntPtr lpTimerName,
+            uint dwFlags,
+            uint dwDesiredAccess);
 
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern bool SetWaitableTimer(


### PR DESCRIPTION
I've been making benchmark and I've noticed default win32 timer implementation had weird timings:
```
| Method | Interval | Mean      | Error    | StdDev   |
|------- |--------- |----------:|---------:|---------:|
| Wait   | 1        |  14.96 ms | 0.116 ms | 0.491 ms |
| Wait   | 10       |  14.97 ms | 0.096 ms | 0.406 ms |
| Wait   | 100      | 108.30 ms | 0.192 ms | 0.812 ms |
```
With CREATE_WAITABLE_TIMER_HIGH_RESOLUTION flag it's working good enough:
```
| Method | Interval | Mean       | Error     | StdDev    |
|------- |--------- |-----------:|----------:|----------:|
| Wait   | 1        |   1.551 ms | 0.0039 ms | 0.0037 ms |
| Wait   | 10       |  10.334 ms | 0.0225 ms | 0.0199 ms |
| Wait   | 100      | 100.099 ms | 0.2187 ms | 0.2045 ms |
```